### PR TITLE
Support new scenarios: no baseline screenshot and size mismatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vasily.strelyaev/testcafe-reporter-dashboard-devextreme",
-  "version": "1.0.0-rc.7",
+  "version": "1.0.0-rc.8",
   "description": "Dashboard TestCafe reporter plugin fork, tailored to the DevExtreme team.",
   "author": {
     "name": "Developer Express Inc.",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "publish-please": "^5.5.2",
     "testcafe": "^1.20.0",
     "ts-node": "^8.7.0",
-    "typescript": "^3.8.3"
+    "typescript": "4.7.4"
   },
   "dependencies": {
     "fp-ts": "^2.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vasily.strelyaev/testcafe-reporter-dashboard-devextreme",
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.9",
   "description": "Dashboard TestCafe reporter plugin fork, tailored to the DevExtreme team.",
   "author": {
     "name": "Developer Express Inc.",

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,4 +1,3 @@
-export const MAX_BUILD_ID_LENGTH            = 100;
 export const CONCURRENT_ERROR_CODE          = 409;
 export const SERVICE_UNAVAILABLE_ERROR_CODE = 503;
 

--- a/src/texts.ts
+++ b/src/texts.ts
@@ -1,4 +1,4 @@
-import { MAX_BUILD_ID_LENGTH } from './consts';
+import { MAX_BUILD_ID_LENGTH } from './types/consts';
 import createReportUrl from './create-report-url';
 
 export const DASHBOARD_LOCATION_NOT_DEFINED  = 'The \'TESTCAFE_DASHBOARD_URL\' environment variable is not defined.';

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,4 +1,4 @@
-import { MAX_BUILD_ID_LENGTH } from '../consts';
+import { MAX_BUILD_ID_LENGTH } from './consts';
 import * as t from 'io-ts';
 
 export interface MaxLengthString<N> {

--- a/src/types/consts.ts
+++ b/src/types/consts.ts
@@ -1,0 +1,1 @@
+export const MAX_BUILD_ID_LENGTH = 100;

--- a/src/types/testcafe.ts
+++ b/src/types/testcafe.ts
@@ -3,13 +3,12 @@ export type ScreenshotUploadIdSet = {
     baseline?: string;
     diff?: string;
     mask?: string;
-    text?: string;
-    textMask?: string;
 };
 
 export type ScreenshotMapItem = {
     path: string;
     ids: ScreenshotUploadIdSet;
+    comparisonFailed?: boolean;
     baselineSourcePath?: string;
     maskSourcePath?: string;
     actionId?: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 import { BrowserInfo } from './types';
 import path from 'path';
+import { FileExistsMethod } from './types/internal';
 
 export function addArrayValueByKey<T> (collection: Record<string, T[]>, key: string, value: T): void {
     if (!collection[key])
@@ -29,4 +30,13 @@ export function replaceLast (string: string, search: string, replace: string): s
 
 export function getPostfixedPath (basePath: string, postfix: string): string {
     return basePath.replace(/\.png$/, `${postfix}.png`);
+}
+
+export async function getScreenshotComparerArtifactsPath (fileExists: FileExistsMethod, filePath: string, screenshotsDir: string, destinationDir: string): Promise<string | undefined> {
+    if (!filePath.includes(path.normalize(screenshotsDir)))
+        return void 0;
+
+    const artifactsPath = replaceLast(filePath, path.normalize(screenshotsDir), path.normalize(destinationDir));
+
+    return await fileExists(artifactsPath) ? artifactsPath : void 0;
 }

--- a/src/validate-settings.ts
+++ b/src/validate-settings.ts
@@ -1,4 +1,4 @@
-import { MAX_BUILD_ID_LENGTH } from './consts';
+import { MAX_BUILD_ID_LENGTH } from './types/consts';
 import {
     AUTHENTICATION_TOKEN_INVALID,
     AUTHENTICATION_TOKEN_NOT_DEFINED,

--- a/test/reporter-methods/test-done.test.ts
+++ b/test/reporter-methods/test-done.test.ts
@@ -128,7 +128,8 @@ describe('reportTestDone', () => {
                 ids: {
                     current: 'upload_id'
                 },
-                path: '%filePath%firefox_1.png'
+                path:             '%filePath%firefox_1.png',
+                comparisonFailed: false
             }
         ]);
 
@@ -139,7 +140,8 @@ describe('reportTestDone', () => {
                 ids: {
                     current: 'upload_id'
                 },
-                path: '%filePath%chrome_1_1.png'
+                path:             '%filePath%chrome_1_1.png',
+                comparisonFailed: false
             }
         ]);
 
@@ -150,7 +152,8 @@ describe('reportTestDone', () => {
                 ids: {
                     current: 'upload_id'
                 },
-                path: '%filePath%chrome_1.png'
+                path:             '%filePath%chrome_1.png',
+                comparisonFailed: false
             }
         ]);
 
@@ -161,7 +164,8 @@ describe('reportTestDone', () => {
                 ids: {
                     current: 'upload_id'
                 },
-                path: '%filePath%chrome_headless_1.png'
+                path:             '%filePath%chrome_headless_1.png',
+                comparisonFailed: false
             }
         ]);
 
@@ -172,7 +176,8 @@ describe('reportTestDone', () => {
                 ids: {
                     current: 'upload_id'
                 },
-                path: '%filePath%chrome_headless_2.png'
+                path:             '%filePath%chrome_headless_2.png',
+                comparisonFailed: false
             }
         ]);
 
@@ -183,7 +188,8 @@ describe('reportTestDone', () => {
                 ids: {
                     current: 'upload_id'
                 },
-                path: '%filePath%chrome_headless.png'
+                path:             '%filePath%chrome_headless.png',
+                comparisonFailed: false
             }
         ]);
 
@@ -219,13 +225,15 @@ describe('reportTestDone', () => {
                 ids: {
                     current: 'upload_id'
                 },
-                path: '%filePath%chrome_1_1.png'
+                path:             '%filePath%chrome_1_1.png',
+                comparisonFailed: false
             },
             {
                 ids: {
                     current: 'upload_id'
                 },
-                path: '%filePath%chrome_1_2.png'
+                path:             '%filePath%chrome_1_2.png',
+                comparisonFailed: false
             }
         ]);
     });

--- a/test/upload-files.test.ts
+++ b/test/upload-files.test.ts
@@ -142,25 +142,19 @@ describe('Uploads', () => {
 
         const pathPrefix      = path.sep === '\\' ? 'C:\\' : '/';
         const screenshotPath1 = `${pathPrefix}testing${path.sep}screenshots${path.sep}1.png`;
+        const artifactsPath1  = `${pathPrefix}testing${path.sep}artifacts${path.sep}compared-screenshots${path.sep}1.png`;
         const baselinePath1   = `${pathPrefix}testing${path.sep}artifacts${path.sep}compared-screenshots${path.sep}1_etalon.png`;
         const diffPath1       = `${pathPrefix}testing${path.sep}artifacts${path.sep}compared-screenshots${path.sep}1_diff.png`;
         const maskPath1       = `${pathPrefix}testing${path.sep}artifacts${path.sep}compared-screenshots${path.sep}1_mask.png`;
-        const textPath1       = `${pathPrefix}testing${path.sep}artifacts${path.sep}compared-screenshots${path.sep}1_text.png`;
-        const textMaskPath1   = `${pathPrefix}testing${path.sep}artifacts${path.sep}compared-screenshots${path.sep}1_text_mask.png`;
         const thumbnailPath1  = `${pathPrefix}testing${path.sep}screenshots${path.sep}thumbnails${path.sep}1.png`;
         const screenshotPath2 = `${pathPrefix}testing${path.sep}screenshots${path.sep}2.png`;
+        const artifactsPath2  = `${pathPrefix}testing${path.sep}artifacts${path.sep}compared-screenshots${path.sep}2.png`;
         const baselinePath2   = `${pathPrefix}testing${path.sep}artifacts${path.sep}compared-screenshots${path.sep}2_etalon.png`;
         const diffPath2       = `${pathPrefix}testing${path.sep}artifacts${path.sep}compared-screenshots${path.sep}2_diff.png`;
         const maskPath2       = `${pathPrefix}testing${path.sep}artifacts${path.sep}compared-screenshots${path.sep}2_mask.png`;
-        const textPath2       = `${pathPrefix}testing${path.sep}artifacts${path.sep}compared-screenshots${path.sep}2_text.png`;
-        const textMaskPath2   = `${pathPrefix}testing${path.sep}artifacts${path.sep}compared-screenshots${path.sep}2_text_mask.png`;
         const thumbnailPath2  = `${pathPrefix}testing${path.sep}screenshots${path.sep}thumbnails${path.sep}2.png`;
         const screenshotPath3 = `${pathPrefix}testing${path.sep}screenshots${path.sep}errors${path.sep}3.png`;
-        const baselinePath3   = `${pathPrefix}testing${path.sep}artifacts${path.sep}compared-screenshots${path.sep}errors${path.sep}3_etalon.png`;
-        const diffPath3       = `${pathPrefix}testing${path.sep}artifacts${path.sep}compared-screenshots${path.sep}errors${path.sep}3_diff.png`;
-        const maskPath3       = `${pathPrefix}testing${path.sep}artifacts${path.sep}compared-screenshots${path.sep}errors${path.sep}3_mask.png`;
-        const textPath3       = `${pathPrefix}testing${path.sep}artifacts${path.sep}compared-screenshots${path.sep}errors${path.sep}3_text.png`;
-        const textMaskPath3   = `${pathPrefix}testing${path.sep}artifacts${path.sep}compared-screenshots${path.sep}errors${path.sep}3_text_mask.png`;
+        const artifactsPath3  = `${pathPrefix}testing${path.sep}artifacts${path.sep}compared-screenshots${path.sep}errors${path.sep}3.png`;
         const thumbnailPath3  = `${pathPrefix}testing${path.sep}screenshots${path.sep}errors${path.sep}thumbnails${path.sep}3.png`;
 
         function readFile (filePath: string): Promise<Buffer> {
@@ -181,12 +175,6 @@ describe('Uploads', () => {
                 case maskPath1:
                     fileContent = 'take_screenshot_action_mask';
                     break;
-                case textPath1:
-                    fileContent = 'take_screenshot_action_text';
-                    break;
-                case textMaskPath1:
-                    fileContent = 'take_screenshot_action_text_mask';
-                    break;
                 case screenshotPath2:
                     fileContent = 'some_other_action';
                     break;
@@ -195,9 +183,6 @@ describe('Uploads', () => {
                     break;
                 case diffPath2:
                     fileContent = 'some_other_action_diff';
-                    break;
-                case textPath2:
-                    fileContent = 'some_other_action_text';
                     break;
                 case screenshotPath3:
                     fileContent = 'screenshot_on_fail';
@@ -210,10 +195,27 @@ describe('Uploads', () => {
         }
 
         function fileExists (filePath: string): Promise<boolean> {
-            if ([baselinePath3, diffPath3, maskPath3, textPath3, textMaskPath3, maskPath2, textMaskPath2].includes(filePath))
+            if ([
+                artifactsPath3,
+                maskPath2
+            ].includes(filePath))
                 return Promise.resolve(false);
 
-            return Promise.resolve(true);
+            if ([
+                screenshotPath1,
+                artifactsPath1,
+                baselinePath1,
+                diffPath1,
+                maskPath1,
+                screenshotPath2,
+                artifactsPath2,
+                baselinePath2,
+                diffPath2,
+                screenshotPath3
+            ].includes(filePath))
+                return Promise.resolve(true);
+
+            throw new Error(`Unknown file path: ${filePath}`);
         }
 
         function reRequireModules () {
@@ -286,34 +288,35 @@ describe('Uploads', () => {
                 }
             });
 
-            const { browserRuns } = JSON.parse(uploadedFiles[11].toString());
+            const { browserRuns } = JSON.parse(uploadedFiles[8].toString());
             const runCommands     = aggregateCommands.filter(command => command.aggregateName === AggregateNames.Run);
 
             assert.equal(runCommands.length, 2);
             assert.equal(runCommands[0].type, AggregateCommandType.reportTaskStart);
             assert.equal(runCommands[1].type, AggregateCommandType.reportTestDone);
 
+            assert.equal(browserRuns['chrome_headless'].screenshotMap[0].path, screenshotPath1);
             assert.equal(browserRuns['chrome_headless'].screenshotMap[0].ids.current, uploadInfos[0].uploadId);
             assert.equal(browserRuns['chrome_headless'].screenshotMap[0].ids.baseline, uploadInfos[1].uploadId);
             assert.equal(browserRuns['chrome_headless'].screenshotMap[0].ids.diff, uploadInfos[2].uploadId);
             assert.equal(browserRuns['chrome_headless'].screenshotMap[0].ids.mask, uploadInfos[3].uploadId);
-            assert.equal(browserRuns['chrome_headless'].screenshotMap[0].ids.text, uploadInfos[4].uploadId);
-            assert.equal(browserRuns['chrome_headless'].screenshotMap[0].ids.textMask, uploadInfos[5].uploadId);
             assert.equal(browserRuns['chrome_headless'].screenshotMap[0].baselineSourcePath, 'testing/tests/suite1/etalons/1.png');
             assert.equal(browserRuns['chrome_headless'].screenshotMap[0].maskSourcePath, 'testing/tests/suite1/etalons/1_mask.png');
-            assert.equal(browserRuns['chrome_headless'].screenshotMap[1].ids.current, uploadInfos[6].uploadId);
-            assert.equal(browserRuns['chrome_headless'].screenshotMap[1].ids.baseline, uploadInfos[7].uploadId);
-            assert.equal(browserRuns['chrome_headless'].screenshotMap[1].ids.diff, uploadInfos[8].uploadId);
-            assert.equal(browserRuns['chrome_headless'].screenshotMap[1].ids.text, uploadInfos[9].uploadId);
+            assert.ok(browserRuns['chrome_headless'].screenshotMap[0].comparisonFailed);
+            assert.equal(browserRuns['chrome_headless'].screenshotMap[1].path, screenshotPath2);
+            assert.equal(browserRuns['chrome_headless'].screenshotMap[1].ids.current, uploadInfos[4].uploadId);
+            assert.equal(browserRuns['chrome_headless'].screenshotMap[1].ids.baseline, uploadInfos[5].uploadId);
+            assert.equal(browserRuns['chrome_headless'].screenshotMap[1].ids.diff, uploadInfos[6].uploadId);
             assert.equal(browserRuns['chrome_headless'].screenshotMap[1].baselineSourcePath, 'testing/tests/suite1/etalons/2.png');
             assert.equal(browserRuns['chrome_headless'].screenshotMap[1].maskSourcePath, 'testing/tests/suite1/etalons/2_mask.png');
-            assert.equal(browserRuns['chrome_headless'].screenshotMap[2].ids.current, uploadInfos[10].uploadId);
-            assert.equal(browserRuns['chrome_headless'].screenshotMap[2].baselineSourcePath, 'testing/tests/suite1/etalons/3.png');
-            assert.equal(browserRuns['chrome_headless'].screenshotMap[2].maskSourcePath, 'testing/tests/suite1/etalons/3_mask.png');
-            assert.equal(runCommands[1].payload.uploadId, uploadInfos[11].uploadId);
+            assert.ok(browserRuns['chrome_headless'].screenshotMap[1].comparisonFailed);
+            assert.equal(browserRuns['chrome_headless'].screenshotMap[2].path, screenshotPath3);
+            assert.equal(browserRuns['chrome_headless'].screenshotMap[2].ids.current, uploadInfos[7].uploadId);
+            assert.equal(browserRuns['chrome_headless'].screenshotMap[2].comparisonFailed, false);
+            assert.equal(runCommands[1].payload.uploadId, uploadInfos[8].uploadId);
 
-            assert.equal(uploadInfos.length, 12);
-            assert.equal(uploadedUrls.length, 12);
+            assert.equal(uploadInfos.length, 9);
+            assert.equal(uploadedUrls.length, 9);
             assert.equal(uploadedUrls[0], uploadInfos[0].uploadUrl);
             assert.equal(uploadedUrls[1], uploadInfos[1].uploadUrl);
             assert.equal(uploadedUrls[2], uploadInfos[2].uploadUrl);
@@ -323,38 +326,30 @@ describe('Uploads', () => {
             assert.equal(uploadedUrls[6], uploadInfos[6].uploadUrl);
             assert.equal(uploadedUrls[7], uploadInfos[7].uploadUrl);
             assert.equal(uploadedUrls[8], uploadInfos[8].uploadUrl);
-            assert.equal(uploadedUrls[9], uploadInfos[9].uploadUrl);
-            assert.equal(uploadedUrls[10], uploadInfos[10].uploadUrl);
-            assert.equal(uploadedUrls[11], uploadInfos[11].uploadUrl);
 
-            assert.equal(uploadedFiles.length, 12);
+            assert.equal(uploadedFiles.length, 9);
             assert.equal(uploadedFiles[0], 'take_screenshot_action');
             assert.equal(uploadedFiles[1], 'take_screenshot_action_etalon');
             assert.equal(uploadedFiles[2], 'take_screenshot_action_diff');
             assert.equal(uploadedFiles[3], 'take_screenshot_action_mask');
-            assert.equal(uploadedFiles[4], 'take_screenshot_action_text');
-            assert.equal(uploadedFiles[5], 'take_screenshot_action_text_mask');
-            assert.equal(uploadedFiles[6], 'some_other_action');
-            assert.equal(uploadedFiles[7], 'some_other_action_etalon');
-            assert.equal(uploadedFiles[8], 'some_other_action_diff');
-            assert.equal(uploadedFiles[9], 'some_other_action_text');
-            assert.equal(uploadedFiles[10], 'screenshot_on_fail');
+            assert.equal(uploadedFiles[4], 'some_other_action');
+            assert.equal(uploadedFiles[5], 'some_other_action_etalon');
+            assert.equal(uploadedFiles[6], 'some_other_action_diff');
+            assert.equal(uploadedFiles[7], 'screenshot_on_fail');
 
-            assert.equal(screenshotPaths.length, 11);
+            assert.equal(screenshotPaths.length, 8);
             assert.equal(screenshotPaths[0], screenshotPath1);
             assert.equal(screenshotPaths[1], baselinePath1);
             assert.equal(screenshotPaths[2], diffPath1);
             assert.equal(screenshotPaths[3], maskPath1);
-            assert.equal(screenshotPaths[4], textPath1);
-            assert.equal(screenshotPaths[5], textMaskPath1);
-            assert.equal(screenshotPaths[6], screenshotPath2);
-            assert.equal(screenshotPaths[7], baselinePath2);
-            assert.equal(screenshotPaths[8], diffPath2);
-            assert.equal(screenshotPaths[9], textPath2);
-            assert.equal(screenshotPaths[10], screenshotPath3);
+            assert.equal(screenshotPaths[4], screenshotPath2);
+            assert.equal(screenshotPaths[5], baselinePath2);
+            assert.equal(screenshotPaths[6], diffPath2);
+            assert.equal(screenshotPaths[7], screenshotPath3);
 
             const uploadCommands = aggregateCommands.filter(command => command.aggregateName === AggregateNames.Upload);
 
+            assert.equal(uploadCommands.length, 9);
             assert.equal(uploadCommands[0].type, AggregateCommandType.createUpload);
             assert.deepEqual(uploadCommands[0].aggregateId, uploadInfos[0].uploadId);
             assert.deepEqual(uploadCommands[0].payload, { status: UploadStatus.Completed });
@@ -390,18 +385,6 @@ describe('Uploads', () => {
             assert.equal(uploadCommands[8].type, AggregateCommandType.createUpload);
             assert.deepEqual(uploadCommands[8].aggregateId, uploadInfos[8].uploadId);
             assert.deepEqual(uploadCommands[8].payload, { status: UploadStatus.Completed });
-
-            assert.equal(uploadCommands[9].type, AggregateCommandType.createUpload);
-            assert.deepEqual(uploadCommands[9].aggregateId, uploadInfos[9].uploadId);
-            assert.deepEqual(uploadCommands[9].payload, { status: UploadStatus.Completed });
-
-            assert.equal(uploadCommands[10].type, AggregateCommandType.createUpload);
-            assert.deepEqual(uploadCommands[10].aggregateId, uploadInfos[10].uploadId);
-            assert.deepEqual(uploadCommands[10].payload, { status: UploadStatus.Completed });
-
-            assert.equal(uploadCommands[11].type, AggregateCommandType.createUpload);
-            assert.deepEqual(uploadCommands[11].aggregateId, uploadInfos[11].uploadId);
-            assert.deepEqual(uploadCommands[11].payload, { status: UploadStatus.Completed });
         });
 
         it('Should upload screenshots from screenshotData', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6693,7 +6693,12 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@^3.3.3, typescript@^3.8.3:
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
+
+typescript@^3.3.3:
   version "3.9.10"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
   integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==


### PR DESCRIPTION
* To support scenarios with no baseline image or mismatched sizes, I introduced a new flag in the `screenshotMapItem` object: `comparisonFailed`.
* The `comparisonFailed` flag is `true` if the screenshot is located in the comparer's output directory (otherwise, it was not produced by the comparer) and a copy of this file is present in the comparer's artifacts directory (which indicates that there was a failure - including "no baseline" or "size mismatch" cases).
* The `comparisonFailed` is always passed to the Dashboard (regardless of whether layout testing is on or off) because that is what indicates if the Dashboard should show the UI.
* Now layout testing failures are uploaded even when the `noScreenshotUpload` flag is enabled (given that `layoutTestingEnabled` is `true`).
* The part where we determine if there is layout testing failure is now shifted earlier to exit ASAP if there is none and screenshots are off.
* No longer upload the `_text` and `_text_mask` artifacts because they are not valuable on their own. Comparer automatically merges them into the `_mask` artifacts if the differences are only in the text (color, opacity).
* I updated the TypeScript version to match TestCafe 2.0 and avoid a compilation error in TS `3.x`.
* I had to move a constant used in `/types` to this directory because TS 4 complained about referencing non-type directory from `/types`.

