### PR TITLE
Should send reportTestDone command  even if `readFile` method fails

### DIFF
--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -1,35 +1,21 @@
-  
 name: Npm audit
 
 on:
   pull_request:
     branches: [ alpha ]
 
-env:
-  VM_MEMORY: 2600
-  VM_CPU: 2
-
-
 jobs:
   run:
-    runs-on: farm
-    strategy:
-      matrix:
-        oses: [UBUNTU]
-    env:
-      VM_IMAGE: ${{ matrix.oses }}
+    runs-on: ubuntu-latest
 
     steps:
       - name: Show ip
         run: ip addr show
-      - name: Clone
-        uses: ./../../checkout
-        with:
-           ref: ${{github.event.pull_request.head.sha}}
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
           node-version: '12.x'
-          registry-url: 'http://npmproxy:4873'
-      - name: npm 
+      - name: npm audit
         run: npm audit

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -16,6 +16,6 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '12.x'
+          node-version: '16.x'
       - name: npm audit
         run: npm audit

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '12.x'
+          node-version: '16.x'
       - name: npm install
         run: npm install
       - name: Run Tests

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -4,31 +4,27 @@ on:
   pull_request:
     branches: [ alpha ]
 
-env:
-  VM_MEMORY: 2600
-  VM_CPU: 1
-
 jobs:
   run:
-    runs-on: farm
+    name: ${{ matrix.args.name }}
+    runs-on: ${{ matrix.args.machineName }}
     strategy:
       matrix:
-        oses: [UBUNTU]
-    env:
-      VM_IMAGE: ${{ matrix.oses }}
+        args: [
+          { name: "Ubuntu", machineName: "ubuntu-latest" },
+          { name: "Windows", machineName: "windows-latest" }
+        ]
 
     steps:
       - name: Show ip
+        if: ${{ matrix.name == 'Ubuntu' }}
         run: ip addr show
-      - name: Clone
-        uses: ./../../checkout
-        with:
-          ref: ${{github.event.pull_request.head.sha}}
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
           node-version: '12.x'
-          registry-url: 'http://npmproxy:4873'
       - name: npm install
         run: npm install
       - name: Run Tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -3745,9 +3745,9 @@
       }
     },
     "node_modules/decode-uri-component": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10"
@@ -14478,9 +14478,9 @@
       "dev": true
     },
     "decode-uri-component": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
       "dev": true
     },
     "dedent": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "testcafe-reporter-dashboard",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "testcafe-reporter-dashboard",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "license": "MIT",
       "dependencies": {
         "es6-promise": "^4.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-reporter-dashboard",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Dashboard TestCafe reporter plugin.",
   "author": {
     "name": "Developer Express Inc.",

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -60,7 +60,16 @@ export class Uploader {
 
         if (!uploadInfo) return void 0;
 
-        const file = await this._readFile(filePath);
+        let file: Buffer | null = null;
+
+        try {
+            file = await this._readFile(filePath);
+        }
+        catch (e) {
+            this._logger.error(e.message);
+
+            return void 0;
+        }
 
         this._uploads.push(this._upload(uploadInfo, file, createFileUploadError(uploadInfo.uploadId, filePath)));
 


### PR DESCRIPTION
For now `reportTestDone` method fails with `Unable to find file` error if a test fails. I happens because testcafe added logic that provide to reporter a buffer with the image, so even if a user doesn't enable `takeOnFails` feature reporter will send a screenshot to Dashboard. In master we have the following logic: https://github.com/DevExpress/testcafe-reporter-dashboard/pull/90/files. But we do not want this feature in alpha version.